### PR TITLE
Update terraform to include VPN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+terra*
+.terr*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 terra*
 .terr*
+.git*

--- a/S3_Bucket_Flow_Logs_aws.tf
+++ b/S3_Bucket_Flow_Logs_aws.tf
@@ -1,5 +1,20 @@
+# #Delete the items in the bucket before destorying
+# resource "null_resource" "delete_bucket_objects" {
+#   provisioner "local-exec" {
+#     command = "aws s3 rm s3://${aws_s3_bucket.s3bucket.bucket} --recursive"
+#   }
+
+#   triggers = {
+#     bucket_name = aws_s3_bucket.s3bucket.bucket
+#   }
+# }
+
+
 resource "aws_s3_bucket" "s3bucket" {
-  bucket = "us-east-1-${data.aws_caller_identity.current.account_id}"
+  bucket = "us-east-2-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+
+  //depends_on = [null_resource.delete_bucket_objects]
 }
 
 data "aws_caller_identity" "current" {}
@@ -11,7 +26,7 @@ resource "aws_flow_log" "flowlogs1" {
   traffic_type      = "ALL"
 
   tags = {
-    Name = "Flow-logs1"
+    Name = "New-Flow-logs1"
   }
 }
 
@@ -22,7 +37,7 @@ resource "aws_flow_log" "flowlogs2" {
   traffic_type      = "ALL"
 
   tags = {
-    Name = "Flow-logs2"
+    Name = "New-Flow-logs2"
   }
 }
 

--- a/aws-vpn.tf
+++ b/aws-vpn.tf
@@ -38,18 +38,18 @@ resource "aws_vpn_gateway" "vpn" {
   
 }
 
-resource "aws_vpn_connection" "vpn" {
-  vpn_gateway_id      = aws_vpn_gateway.vpn.id
-    customer_gateway_id = aws_customer_gateway.vpn.id
-    type               = "ipsec.1"
-  static_routes_only = true
-  tunnel1_preshared_key = var.vpn_shared_key
+  resource "aws_vpn_connection" "vpn" {
+    vpn_gateway_id      = aws_vpn_gateway.vpn.id
+      customer_gateway_id = aws_customer_gateway.vpn.id
+      type               = "ipsec.1"
+    static_routes_only = true
+    tunnel1_preshared_key = var.vpn_shared_key
 
-  tags = {
-    Name = "azure-vpn-connection"
+    tags = {
+      Name = "azure-vpn-connection"
+    }
+    //depends_on = [aws_vpn_gateway.vpn,aws_customer_gateway.vpn]
   }
-  //depends_on = [aws_vpn_gateway.vpn,aws_customer_gateway.vpn]
-}
 
 resource "aws_vpn_connection_route" "azure_VNetA" {
   destination_cidr_block = var.azure_vnetA_cidr

--- a/aws-vpn.tf
+++ b/aws-vpn.tf
@@ -1,0 +1,122 @@
+# Provider configuration
+# Variables
+variable "vpn_shared_key" {
+  description = "Shared key for VPN connection"
+  sensitive   = true
+  default = "Illumio123"
+}
+
+# AWS Resources
+
+resource "aws_subnet" "vpn" {
+  vpc_id     = aws_vpc.vpc1.id
+  cidr_block = cidrsubnet(var.aws_vpc1_cidr, 8, 4)
+
+  tags = {
+    Name = "vpn-subnet"
+  }
+}
+
+resource "aws_customer_gateway" "vpn" {
+  bgp_asn    = 65000
+  ip_address = azurerm_public_ip.vpn_pip.ip_address
+  type       = "ipsec.1"
+
+  tags = {
+    Name = "azure-customer-gateway"
+  }
+
+  depends_on = [azurerm_public_ip.vpn_pip]
+}
+
+resource "aws_vpn_gateway" "vpn" {
+  vpc_id = aws_vpc.vpc1.id
+
+  tags = {
+    Name = "aws-vpn-gateway"
+  }
+  
+}
+
+resource "aws_vpn_connection" "vpn" {
+  vpn_gateway_id      = aws_vpn_gateway.vpn.id
+    customer_gateway_id = aws_customer_gateway.vpn.id
+    type               = "ipsec.1"
+  static_routes_only = true
+  tunnel1_preshared_key = var.vpn_shared_key
+
+  tags = {
+    Name = "azure-vpn-connection"
+  }
+  //depends_on = [aws_vpn_gateway.vpn,aws_customer_gateway.vpn]
+}
+
+resource "aws_vpn_connection_route" "azure_VNetA" {
+  destination_cidr_block = var.azure_vnetA_cidr
+  vpn_connection_id      = aws_vpn_connection.vpn.id
+}
+resource "aws_vpn_connection_route" "azure_VNetB" {
+  destination_cidr_block = var.azure_vnetB_cidr
+  vpn_connection_id      = aws_vpn_connection.vpn.id
+}
+
+# Route Tables
+# Create a Route for Internet Gateway To VNETA & VENTB
+# resource "aws_route" "azure_routeA" {
+#   route_table_id         = aws_route_table.public_rt.id
+#   destination_cidr_block = var.azure_vnetA_cidr
+#   gateway_id             = aws_vpn_gateway.vpn.id
+# }
+# resource "aws_route" "azure_routeB" {
+#   route_table_id         = aws_route_table.public_rt.id
+#   destination_cidr_block = var.azure_vnetB_cidr
+#   gateway_id             = aws_vpn_gateway.vpn.id
+# }
+
+resource "aws_vpn_gateway_route_propagation" "example" {
+  vpn_gateway_id = aws_vpn_gateway.vpn.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_route_table_association" "vpn" {
+  subnet_id      = aws_subnet.vpn.id
+  route_table_id = aws_route_table.public_rt.id
+  
+}
+
+# Security Groups
+resource "aws_security_group" "vpn" {
+  name        = "vpn-security-group"
+  description = "Allow traffic from Azure VNet"
+  vpc_id      = aws_vpc.vpc1.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.azure_vnetA_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "vpn-security-group"
+  }
+}
+
+# Outputs
+output "aws_vpn_connection_id" {
+  value = aws_vpn_connection.vpn.id
+}
+output "aws_vpn_connection_tunnel1_address" {
+  value = aws_vpn_connection.vpn.tunnel1_address
+}
+
+output "aws_vpn_connection_tunnel2_address" {
+  value = aws_vpn_connection.vpn.tunnel2_address
+}

--- a/azure-vpn.tf
+++ b/azure-vpn.tf
@@ -14,6 +14,8 @@ resource "azurerm_public_ip" "vpn_pip" {
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Static"
   sku         = "Standard"
+
+  zones = []
 }
 
 
@@ -32,7 +34,8 @@ resource "azurerm_virtual_network_gateway" "vpn_gateway" {
     name                          = "vnetGatewayConfig"
     public_ip_address_id         = azurerm_public_ip.vpn_pip.id
     private_ip_address_allocation = "Dynamic"
-    subnet_id                     = "${azurerm_virtual_network.vnetA.id}/subnets/GatewaySubnet"
+   // subnet_id                     = "${azurerm_virtual_network.vnetA.id}/subnets/GatewaySubnet"
+    subnet_id                    = azurerm_subnet.GatewaySubnet.id 
   }
 
   depends_on = [ azurerm_local_network_gateway.aws_lng,azurerm_subnet.GatewaySubnet ]

--- a/azure-vpn.tf
+++ b/azure-vpn.tf
@@ -1,0 +1,81 @@
+# Azure Resources
+resource "azurerm_subnet" "GatewaySubnet" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnetA.name
+  address_prefixes     = [cidrsubnet(var.azure_vnetA_cidr, 3, 1)]
+
+   depends_on = [ azurerm_subnet.subnetA ]
+}
+
+resource "azurerm_public_ip" "vpn_pip" {
+  name                = "vpn-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku         = "Standard"
+}
+
+
+
+resource "azurerm_virtual_network_gateway" "vpn_gateway" {
+  name                = "azure-vpn-gateway"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  type               = "Vpn"
+  vpn_type           = "RouteBased"
+  active_active = false
+  enable_bgp    = false
+  sku           = "VpnGw1AZ"
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id         = azurerm_public_ip.vpn_pip.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = "${azurerm_virtual_network.vnetA.id}/subnets/GatewaySubnet"
+  }
+
+  depends_on = [ azurerm_local_network_gateway.aws_lng,azurerm_subnet.GatewaySubnet ]
+}
+
+resource "azurerm_local_network_gateway" "aws_lng" {
+  name                = "aws-local-network-gateway"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  gateway_address     = aws_vpn_connection.vpn.tunnel1_address
+  address_space       = [var.aws_vpc1_cidr,var.aws_vpc2_cidr]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "azure_to_aws" {
+  name                       = "azure-to-aws"
+  location                   = azurerm_resource_group.rg.location
+  resource_group_name        = azurerm_resource_group.rg.name
+  type                       = "IPsec"
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.vpn_gateway.id
+  local_network_gateway_id   = azurerm_local_network_gateway.aws_lng.id
+  shared_key                 = var.vpn_shared_key
+
+  depends_on = [ azurerm_local_network_gateway.aws_lng,azurerm_virtual_network_gateway.vpn_gateway ]
+}
+
+# resource "azurerm_network_security_group" "vpn" {
+#   name                = "vpn-security-group"
+#   location            = azurerm_resource_group.rg.location
+#   resource_group_name = azurerm_resource_group.rg.name
+
+#   security_rule {
+#     name                       = "AllowVPNTraffic"
+#     priority                   = 100
+#     direction                  = "Inbound"
+#     access                     = "Allow"
+#     protocol                   = "*"
+#     source_port_range         = "*"
+#     destination_port_range    = "*"
+#     source_address_prefix     = var.aws_vpc1_cidr
+#     destination_address_prefix = var.azure_vnetA_cidr
+#   }
+# }
+
+output "azure_public_ip_vpn_ip" {
+  value = azurerm_public_ip.vpn_pip.ip_address
+}

--- a/flowlogs_azure.tf
+++ b/flowlogs_azure.tf
@@ -1,8 +1,13 @@
 
 resource "azurerm_network_watcher" "NetWatcher" {
-  name                = "NetworkWatcher_westus"
+  name                = "NetworkWatcher_${var.azure_location}"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
+  # lifecycle {
+
+  #   ignore_changes = [ name, location ]
+
+  # }
 }
 
 resource "random_string" "random" {

--- a/main_aws.tf
+++ b/main_aws.tf
@@ -1,11 +1,30 @@
 provider "aws" {
-  region = "us-east-1" 
+  region = var.aws_location
 }
 
-variable "instance_ami" {
-  description = "EC2 instance ami"
+# variable "instance_ami" {
+#   description = "EC2 instance ami"
+#   type        = string
+#   default     = "ami-0182f373e66f89c85"
+# }
+
+data "aws_ami" "amazon-linux" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+variable "aws_location" {
+  description = "AWS location"
   type        = string
-  default     = "ami-0182f373e66f89c85"
+  default     = "us-east-2"
 }
 
 variable "instance_type" {
@@ -17,5 +36,15 @@ variable "instance_type" {
 variable "subnet_availability_zone" {
   description = "Subnet Availablity Zone"
   type        = string
-  default     = "us-east-1a"
+  default     = "us-east-2a"
+}
+
+
+variable "aws_vpc1_cidr" {
+  description = "AWS VPC1 CIDR"
+  default     = "10.0.0.0/16"
+}
+variable "aws_vpc2_cidr" {
+  description = "AWS VPC2 CIDR"
+  default     = "10.10.0.0/16"
 }

--- a/main_azure.tf
+++ b/main_azure.tf
@@ -22,9 +22,26 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "testdrive"
-  location = "West US"
+  location = var.azure_location
 
   tags = {
     environment = "Production"
   }
+}
+variable "azure_location" {
+  description = "Azure region"
+  type        = string
+  default     = "eastus"
+}
+
+variable "azure_vnetA_cidr" {
+  description = "Azure VNet1 CIDR"
+  type        = string
+  default     = "192.168.1.0/24"
+}
+
+variable "azure_vnetB_cidr" {
+  description = "Azure VNet2 CIDR"
+  type        = string
+  default     = "192.168.2.0/24"
 }

--- a/network1_aws.tf
+++ b/network1_aws.tf
@@ -1,6 +1,6 @@
 # VPC1
 resource "aws_vpc" "vpc1" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = var.aws_vpc1_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
   tags = {
@@ -22,7 +22,7 @@ resource "aws_internet_gateway" "igw" {
 # Public Subnet VPC1 - For Jumphost
 resource "aws_subnet" "public_subnet" {
   vpc_id            = aws_vpc.vpc1.id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = cidrsubnet(var.aws_vpc1_cidr, 8, 1)
   map_public_ip_on_launch = true
   availability_zone = var.subnet_availability_zone # Specify your availability zone
 
@@ -34,7 +34,7 @@ resource "aws_subnet" "public_subnet" {
 # Prod Subnet - private subnet
 resource "aws_subnet" "prod_subnet" {
   vpc_id            = aws_vpc.vpc1.id
-  cidr_block        = "10.0.2.0/24"
+  cidr_block        = cidrsubnet(var.aws_vpc1_cidr, 8, 2)
   availability_zone = var.subnet_availability_zone
 
   tags = {
@@ -45,7 +45,7 @@ resource "aws_subnet" "prod_subnet" {
 # Dev Subnet - private subnet
 resource "aws_subnet" "dev_subnet" {
   vpc_id            = aws_vpc.vpc1.id
-  cidr_block        = "10.0.3.0/24"
+  cidr_block        = cidrsubnet(var.aws_vpc1_cidr, 8, 3)
   availability_zone = var.subnet_availability_zone
 
   tags = {
@@ -78,7 +78,7 @@ resource "aws_route" "public_route" {
 # Create a Route for Staging peering
 resource "aws_route" "public_to_staging_route" {
   route_table_id         = aws_route_table.public_rt.id
-  destination_cidr_block = "10.10.0.0/16"
+  destination_cidr_block = var.aws_vpc2_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.vpc1-to-vpc2-peering.id
 }
 
@@ -116,7 +116,7 @@ resource "aws_route" "private_route" {
 # Create a Route for Staging peering in the Private Route tab;e
 resource "aws_route" "private_to_staging_route" {
   route_table_id         = aws_route_table.private_rt.id
-  destination_cidr_block = "10.10.0.0/16"
+  destination_cidr_block = var.aws_vpc2_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.vpc1-to-vpc2-peering.id
 }
 

--- a/network2_aws.tf
+++ b/network2_aws.tf
@@ -1,6 +1,6 @@
 # VPC1
 resource "aws_vpc" "vpc2" {
-  cidr_block = "10.10.0.0/16"
+  cidr_block = var.aws_vpc2_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
   tags = {
@@ -11,8 +11,8 @@ resource "aws_vpc" "vpc2" {
 # Staging Subnet VPC2 - For Jumphost
 resource "aws_subnet" "staging_subnet" {
   vpc_id            = aws_vpc.vpc2.id
-  cidr_block        = "10.10.4.0/24"
-  availability_zone = "us-east-1a" # Specify your availability zone
+  cidr_block        =cidrsubnet(var.aws_vpc2_cidr, 8, 4 )
+  availability_zone = var.subnet_availability_zone # Specify your availability zone
 
   tags = {
     Name = "Staging-Subnet"
@@ -48,6 +48,6 @@ resource "aws_route_table_association" "staging_association" {
 # Create a Route for VPC peering
 resource "aws_route" "vpc2_vpc1_route" {
   route_table_id         = aws_route_table.staging_rt.id
-  destination_cidr_block = "10.0.0.0/16"
+  destination_cidr_block = var.aws_vpc1_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.vpc1-to-vpc2-peering.id
 }

--- a/network_azure.tf
+++ b/network_azure.tf
@@ -2,13 +2,13 @@
 # Create virtual network
 resource "azurerm_virtual_network" "vnetA" {
   name                = "vnetA"
-  address_space       = ["192.168.1.0/24"]
+  address_space       = [var.azure_vnetA_cidr]
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
 }
 resource "azurerm_virtual_network" "vnetB" {
   name                = "vnetB"
-  address_space       = ["192.168.2.0/24"]
+  address_space       = [var.azure_vnetB_cidr]
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
 }
@@ -29,13 +29,13 @@ resource "azurerm_subnet" "subnetA" {
   name                 = "subnetA"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnetA.name
-  address_prefixes     = ["192.168.1.0/27"]
+  address_prefixes     = [cidrsubnet(var.azure_vnetA_cidr, 3, 0)]
 }
 resource "azurerm_subnet" "subnetB" {
   name                 = "subnetB"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnetB.name
-  address_prefixes     = ["192.168.2.0/27"]
+  address_prefixes     = [cidrsubnet(var.azure_vnetB_cidr, 3, 0)]
 }
 
 

--- a/prod_subnet_resources_aws.tf
+++ b/prod_subnet_resources_aws.tf
@@ -2,7 +2,7 @@
 # -----Create Point-of-sale Prod app----------
 # --------------------------------------------
 resource "aws_instance" "pos-web01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -31,7 +31,7 @@ resource "aws_instance" "pos-web01-prd" {
 }
 
 resource "aws_instance" "pos-proc01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -60,7 +60,7 @@ resource "aws_instance" "pos-proc01-prd" {
 }
 
 resource "aws_instance" "pos-db01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -92,7 +92,7 @@ resource "aws_instance" "pos-db01-prd" {
 # --------------------------------------------
 
 resource "aws_instance" "hr-web01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -120,7 +120,7 @@ resource "aws_instance" "hr-web01-prd" {
 }
 
 resource "aws_instance" "hr-proc01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -149,7 +149,7 @@ resource "aws_instance" "hr-proc01-prd" {
 }
 
 resource "aws_instance" "hr-db01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -181,7 +181,7 @@ resource "aws_instance" "hr-db01-prd" {
 # --------------------------------------------
 
 resource "aws_instance" "crm-web01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -210,7 +210,7 @@ resource "aws_instance" "crm-web01-prd" {
 }
 
 resource "aws_instance" "crm-proc01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id
@@ -239,7 +239,7 @@ resource "aws_instance" "crm-proc01-prd" {
 }
 
 resource "aws_instance" "crm-db01-prd" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.prod_subnet.availability_zone
   subnet_id              = aws_subnet.prod_subnet.id

--- a/public_subnet_resources_aws.tf
+++ b/public_subnet_resources_aws.tf
@@ -1,6 +1,6 @@
 #Create Jumpbox on Public Subnet
 resource "aws_instance" "jumphost01" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.public_subnet.availability_zone
   subnet_id              = aws_subnet.public_subnet.id

--- a/resources_azure.tf
+++ b/resources_azure.tf
@@ -74,6 +74,7 @@ resource "azurerm_network_watcher_flow_log" "nw_flowlogs_ticketing-web01-dev" {
   name                 = "nsg-flow-logs-ticketing-web01-dev"
 
   network_security_group_id = azurerm_network_security_group.nsg-ticketing-web01-dev.id
+  //target_resource_id = azurerm_network_security_group.nsg-ticketing-web01-dev.id
   storage_account_id        = azurerm_storage_account.flowlogs.id
   enabled                   = true
   version = 2
@@ -95,6 +96,8 @@ resource "azurerm_network_interface" "nic-A" {
         private_ip_address = "192.168.1.6"
 
   }
+
+depends_on = [ azurerm_network_watcher.NetWatcher ]
 }
 resource "azurerm_network_interface_security_group_association" "assocA" {
   network_interface_id      = azurerm_network_interface.nic-A.id
@@ -155,6 +158,7 @@ resource "azurerm_network_watcher_flow_log" "nw_flowlogs_ticketing-jump01" {
   name                 = "nsg-flow-logs-ticketing-jump01"
 
   network_security_group_id = azurerm_network_security_group.nsg-ticketing-jump01.id
+  //target_resource_id = azurerm_network_security_group.nsg-ticketing-jump01.id
   storage_account_id        = azurerm_storage_account.flowlogs.id
   enabled                   = true
   version = 2
@@ -163,6 +167,8 @@ resource "azurerm_network_watcher_flow_log" "nw_flowlogs_ticketing-jump01" {
     enabled = true
     days    = 1
   }
+
+  depends_on = [ azurerm_network_watcher.NetWatcher ]
 }
 resource "azurerm_network_interface" "nic-C" {
   name                = "nic-C"
@@ -237,7 +243,9 @@ resource "azurerm_network_watcher_flow_log" "nw_flowlogs_ticketing-web01-prod" {
   //resource_group_name = "NetworkWatcherRG"
   name                 = "nsg-flow-logs-ticketing-web01-prod"
 
+  
   network_security_group_id = azurerm_network_security_group.nsg-ticketing-web01-prod.id
+  //target_resource_id = azurerm_network_security_group.nsg-ticketing-web01-prod.id
   storage_account_id        = azurerm_storage_account.flowlogs.id
   enabled                   = true
   version = 2
@@ -258,6 +266,8 @@ resource "azurerm_network_interface" "nic-B" {
     private_ip_address_allocation = "Static"
     private_ip_address = "192.168.2.6"
   }
+
+  depends_on = [ azurerm_network_watcher.NetWatcher ]
 }
 
 # Connect the security group to the network interface
@@ -317,6 +327,7 @@ resource "azurerm_network_watcher_flow_log" "nw_flowlogs_ticketing-proc01-prod" 
   name                 = "nsg-flow-logs-ticketing-proc01-prod"
 
   network_security_group_id = azurerm_network_security_group.nsg-ticketing-proc01-prod.id
+  //target_resource_id  = azurerm_network_security_group.nsg-ticketing-proc01-prod.id
   storage_account_id        = azurerm_storage_account.flowlogs.id
   enabled                   = true
   version = 2
@@ -337,6 +348,8 @@ resource "azurerm_network_interface" "nic-D" {
     private_ip_address_allocation = "Static"
     private_ip_address = "192.168.2.7"
   }
+
+  depends_on = [ azurerm_network_watcher.NetWatcher ]
 }
 
 # Connect the security group to the network interface

--- a/stage_subnet_resources_aws.tf
+++ b/stage_subnet_resources_aws.tf
@@ -3,7 +3,7 @@
 # --------------------------------------------
 
 resource "aws_instance" "crm-web01-stg" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.staging_subnet.availability_zone
   subnet_id              = aws_subnet.staging_subnet.id
@@ -32,7 +32,7 @@ resource "aws_instance" "crm-web01-stg" {
 }
 
 resource "aws_instance" "crm-proc01-stg" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.staging_subnet.availability_zone
   subnet_id              = aws_subnet.staging_subnet.id
@@ -61,7 +61,7 @@ resource "aws_instance" "crm-proc01-stg" {
 }
 
 resource "aws_instance" "crm-db01-stg" {
-  ami                    = var.instance_ami
+  ami                    = data.aws_ami.amazon-linux.id
   instance_type          = var.instance_type
   availability_zone      = aws_subnet.staging_subnet.availability_zone
   subnet_id              = aws_subnet.staging_subnet.id


### PR DESCRIPTION
I have updated your terraform plan with vpn capability between AWS and Azure.  This change will add an additional 10-15 minutes of build time to the terraform plan.   Also, I cannot get the plan to work without using a zone redundant gateway (VpnGW1Az).  I parameterized the networks being used for the networks but DID NOT update the static IPs on the workloads.  I can look into doing that but currently the scripts to perform traffic creation is no easily parameterized.  Might make sense to build a tool to built the traffic vs using telnet and telnet commands vs variable CSV files like vensim traffic
